### PR TITLE
Move the Gem::Specification to bacon.gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ ann-*
 *.tar.gz
 doc
 pkg
+*.gem

--- a/Rakefile
+++ b/Rakefile
@@ -78,53 +78,6 @@ task :test do
 end
 
 
-begin
-  $" << "sources"  if defined? FromSrc
-  require 'rubygems'
-
-  require 'rake'
-  require 'rake/clean'
-  require 'rake/packagetask'
-  require 'rake/gempackagetask'
-  require 'fileutils'
-rescue LoadError
-  # Too bad.
-else
-  spec = Gem::Specification.new do |s|
-    s.name            = "bacon"
-    s.version         = gem_version
-    s.platform        = Gem::Platform::RUBY
-    s.summary         = "a small RSpec clone"
-
-    s.description = <<-EOF
-Bacon is a small RSpec clone weighing less than 350 LoC but
-nevertheless providing all essential features.
-
-http://github.com/chneukirchen/bacon
-    EOF
-
-    s.files           = manifest + %w(RDOX ChangeLog)
-    s.bindir          = 'bin'
-    s.executables     << 'bacon'
-    s.require_path    = 'lib'
-    s.has_rdoc        = true
-    s.extra_rdoc_files = ['README', 'RDOX']
-    s.test_files      = []
-
-    s.author          = 'Christian Neukirchen'
-    s.email           = 'chneukirchen@gmail.com'
-    s.homepage        = 'http://github.com/chneukirchen/bacon'
-  end
-
-  task :gem => [:chmod, :changelog]
-
-  Rake::GemPackageTask.new(spec) do |p|
-    p.gem_spec = spec
-    p.need_tar = false
-    p.need_zip = false
-  end
-end
-
 desc "Generate RDoc documentation"
 Rake::RDocTask.new(:rdoc) do |rdoc|
   rdoc.options << '--line-numbers' << '--inline-source' <<

--- a/bacon.gemspec
+++ b/bacon.gemspec
@@ -1,0 +1,25 @@
+Gem::Specification.new do |s|
+  s.name            = "bacon"
+  s.version         = '1.1.11'
+  s.platform        = Gem::Platform::RUBY
+  s.summary         = "a small RSpec clone"
+
+  s.description = <<-EOF
+Bacon is a small RSpec clone weighing less than 350 LoC but
+nevertheless providing all essential features.
+
+http://github.com/chneukirchen/bacon
+  EOF
+
+  s.files           = `git ls-files`.split("\n") - [".gitignore"] + %w(RDOX ChangeLog)
+  s.bindir          = 'bin'
+  s.executables     << 'bacon'
+  s.require_path    = 'lib'
+  s.has_rdoc        = true
+  s.extra_rdoc_files = ['README', 'RDOX']
+  s.test_files      = []
+
+  s.author          = 'Christian Neukirchen'
+  s.email           = 'chneukirchen@gmail.com'
+  s.homepage        = 'http://github.com/chneukirchen/bacon'
+end


### PR DESCRIPTION
So the gem can be built and released using `gem build` and `gem push` and to allow
tools like Bundler to install Bacon from git or from the local filesystem. :)
