### PR TITLE
add travis to see tests pass on supported rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm:
 - rbx-19mode
 - jruby-18mode
 - jruby-19mode
+notifications:
+  recipients:
+  - gabriel.horner@gmail.com
 matrix:
   # until issues are fixed
   allow_failures:


### PR DESCRIPTION
Would be great to add travis so users can see bacon's test suite across rubies i.e. http://travis-ci.org/#!/cldwalker/bacon/builds/880935

Test suite looks good for mri. There are failing tests for jruby + rbx so I've set them as allowed to fail until fixed. I have a jruby fix coming soon
