### PR TITLE
fix for latest jruby where should.== fails for arrays

### DIFF
--- a/lib/bacon.rb
+++ b/lib/bacon.rb
@@ -132,13 +132,13 @@ module Bacon
 
   class Context
     attr_reader :name, :block
-    
+
     def initialize(name, &block)
       @name = name
       @before, @after = [], []
       @block = block
     end
-    
+
     def run
       return  unless name =~ RestrictContext
       Counter[:context_depth] += 1
@@ -160,7 +160,7 @@ module Bacon
       Counter[:specifications] += 1
       run_requirement description, block
     end
-    
+
     def should(*args, &block)
       if Counter[:depth]==0
         it('should '+args.first,&block)
@@ -326,7 +326,7 @@ class Should
       description = ""
     end
 
-    r = yield(@object, *args)
+    r = yield(@object)
     if Bacon::Counter[:depth] > 0
       Bacon::Counter[:requirements] += 1
       raise Bacon::Error.new(:failed, description)  unless @negated ^ r

--- a/test/spec_bacon.rb
+++ b/test/spec_bacon.rb
@@ -27,7 +27,7 @@ end
 
 describe "Bacon" do
   extend MetaTests
-  
+
   it "should have should.satisfy" do
     lambda { should.satisfy { 1 == 1 } }.should succeed
     lambda { should.satisfy { 1 } }.should succeed
@@ -38,6 +38,14 @@ describe "Bacon" do
 
     lambda { 1.should.satisfy { |n| n % 2 == 0 } }.should fail
     lambda { 2.should.satisfy { |n| n % 2 == 0 } }.should succeed
+  end
+
+  it "should have should.==" do
+    lambda { "string1".should == "string1" }.should succeed
+    lambda { "string1".should == "string2" }.should fail
+
+    lambda { [1,2,3].should == [1,2,3] }.should succeed
+    lambda { [1,2,3].should == [1,2,4] }.should fail
   end
 
   it "should have should.equal" do
@@ -96,7 +104,7 @@ describe "Bacon" do
     ex.should.be.kind_of RuntimeError
     ex.message.should =~ /foo/
   end
-  
+
   it "should have should.be.an.instance_of" do
     lambda { "string".should.be.instance_of String }.should succeed
     lambda { "string".should.be.instance_of Hash }.should fail
@@ -149,7 +157,7 @@ describe "Bacon" do
         }.should.not.raise(RuntimeError, Comparable)
       }.should.raise ZeroDivisionError
     }.should succeed
-      
+
     lambda { lambda { raise "Error" }.should.not.raise }.should fail
   end
 
@@ -193,7 +201,7 @@ describe "Bacon" do
     lambda { 5.should.respond_to :to_str }.should fail
     lambda { :foo.should.respond_to :nx }.should fail
   end
-  
+
   it "should have should.be.close" do
     lambda { 1.4.should.be.close 1.4, 0 }.should succeed
     lambda { 0.4.should.be.close 0.5, 0.1 }.should succeed
@@ -290,40 +298,40 @@ describe "before/after" do
   after do
     @a.should.equal 3
   end
-  
+
   it "should run in the right order" do
     @a.should.equal 2
     @b.should.equal 2
   end
-  
+
   describe "when nested" do
     before do
       @c = 5
     end
-    
+
     it "should run from higher level" do
       @a.should.equal 2
       @b.should.equal 2
     end
-    
+
     it "should run at the nested level" do
       @c.should.equal 5
     end
-    
+
     before do
       @a = 5
     end
-    
+
     it "should run in the right order" do
       @a.should.equal 5
       @a = 2
     end
   end
-  
+
   it "should not run from lower level" do
     @c.should.be.nil
   end
-  
+
   describe "when nested at a sibling level" do
     it "should not run from sibling level" do
       @c.should.be.nil
@@ -391,7 +399,7 @@ describe 'describe arguments' do
   it 'should work with symbols' do
     check(describe(:behaviour) {},'behaviour')
   end
-   
+
   it 'should work with modules' do
     check(describe(Bacon) {},'Bacon')
   end


### PR DESCRIPTION
- removing splatted args to Should#satisfy's yield fixes issue
  - removed since there is no tests for args behavior
  - args aren't used in Should#method_missing
- jruby bug has been filed: http://jira.codehaus.org/browse/JRUBY-6550
- This fix fixes 2 of the 3 jruby-1.9 failing tests: http://travis-ci.org/#!/cldwalker/bacon/jobs/880942

It would be great to get this in a release as I'd like to test jruby-1.9 for multiple projects. Do you want a separate pull request to bump the version?
