### PR TITLE
Fixed invalid gemspec warnings

### DIFF
--- a/bacon.gemspec
+++ b/bacon.gemspec
@@ -11,12 +11,12 @@ nevertheless providing all essential features.
 http://github.com/chneukirchen/bacon
   EOF
 
-  s.files           = `git ls-files`.split("\n") - [".gitignore"] + %w(ChangeLog)
+  s.files           = `git ls-files`.split("\n") - [".gitignore"] + %w()
   s.bindir          = 'bin'
   s.executables     << 'bacon'
   s.require_path    = 'lib'
   s.has_rdoc        = true
-  s.extra_rdoc_files = ['README']
+  s.extra_rdoc_files = []
   s.test_files      = []
 
   s.author          = 'Christian Neukirchen'


### PR DESCRIPTION
The notices were getting annoying so I decided to just make the gemspec valid. 
Nothing code related so it is not urgent at all. 
