### PR TITLE
Avoid undef'ing _? in order to support coalesce gem

### DIFF
--- a/lib/bacon.rb
+++ b/lib/bacon.rb
@@ -290,7 +290,8 @@ end
 class Should
   # Kills ==, ===, =~, eql?, equal?, frozen?, instance_of?, is_a?,
   # kind_of?, nil?, respond_to?, tainted?
-  instance_methods.each { |name| undef_method name  if name =~ /\?|^\W+$/ }
+  # Special exception for _? to support the 'coalesce' gem
+  instance_methods.each { |name| undef_method name  if name =~ /(?<!^_)\?|^\W+$/ }
 
   def initialize(object)
     @object = object


### PR DESCRIPTION
I wrote a gem called "coalesce" that defines a method `_?` on `Object`. However, this method gets undefined as soon as bacon gets required, causing my code to fail.

The code in question undefines any method that either ends in ? or is all non-word characters.

This patch exempts _? from undefinement. (totally a word)

Considering the number of tools and individuals that add neat little `Object` methods like this, I can't imagine I'm the first person to get bitten by this. Maybe there's a better way to handle this overall.
