### PR TITLE
Introduce customizable error descriptions.

### DIFF
--- a/bin/bacon
+++ b/bin/bacon
@@ -7,6 +7,7 @@ module Bacon; end
 
 automatic = false
 output = 'SpecDoxOutput'
+error  = 'InlineErrorDescription'
 
 options = OptionParser.new("", 24, '  ') { |opts|
   opts.banner = "Usage: bacon [options] [files | -a] [-- untouched arguments]"
@@ -57,6 +58,22 @@ options = OptionParser.new("", 24, '  ') { |opts|
           "do FORMAT (SpecDox/TestUnit/Tap) output") { |format|
     output = format + "Output" 
   }
+
+  opts.on("-i", "--inline",  "show errors inlined (default)") {
+    error = 'InlineErrorDescription'
+  }
+  opts.on("-l", "--newline", "show errors with newlines") {
+    error = 'NewlineErrorDescription'
+  }
+  opts.on("-f", "--diff",    "show errors with diff command") {
+    error = 'DiffErrorDescription'
+  }
+
+  opts.on("--error DESCRIPTOR",
+          "show errors with DESCRIPTOR (Inline/Newline/Diff)") { |descriptor|
+    error = descriptor + "ErrorDescription"
+  }
+
   opts.on("-Q", "--no-backtrace", "don't print backtraces") {
     Bacon.const_set :Backtraces, false
   }
@@ -110,6 +127,7 @@ end
 require 'bacon'
 
 Bacon.extend Bacon.const_get(output) rescue abort "No such formatter: #{output}"
+Bacon.extend Bacon.const_get(error) rescue abort "No such error descriptor: #{error}"
 Bacon.summary_on_exit
 
 files.each { |file|


### PR DESCRIPTION
The original one is the default, which is InlineErrorDescription.
In the command line, use -i, or --inline.

The second one would try to put the expected result and actual
result with newlines, which is much easier to tell the difference
with human eyes when the inspected string is quite long.
For example, try to test a markdown formatter with a long text.
In the command line, use -l, or --newline.

The last one tries to put this further with external diff command.
Which might not be as portable as the one in minitest, but could be
already useful on most of the platforms other than Windows.
In the command line, use -f, or --diff.

Just try to be consistent with formatter argument, we also provide
--error which you could specify Inline, Newline, or Diff, or even
user provided error descriptors. However I failed to find a letter
for this argument. I guess providing --error might be good enough.
