### PR TITLE
Specifications with just a name correctly flunks with "not implemented"

### DIFF
--- a/lib/bacon.rb
+++ b/lib/bacon.rb
@@ -156,7 +156,7 @@ module Bacon
 
     def it(description, &block)
       return  unless description =~ RestrictName
-      block ||= lambda { should.flunk "not implemented" }
+      block ||= proc { should.flunk "not implemented" }
       Counter[:specifications] += 1
       run_requirement description, block
     end


### PR DESCRIPTION
The default lambda used in #it causes the instance_eval to fail in #run_requirement since instance_eval pass self as an argument. Using a proc solves this problem.

I tried to set up tests for this error case but the production code is to tightly integrated to write them in an easy way.
