### PR TITLE
Add option to shuffle test files.

### DIFF
--- a/bin/bacon
+++ b/bin/bacon
@@ -6,7 +6,7 @@ $LOAD_PATH.unshift File.join(File.dirname(__FILE__), '../lib/')
 module Bacon; end
 
 automatic = false
-shuffling = [:to_a]
+random = Random.new
 output = 'SpecDoxOutput'
 
 options = OptionParser.new("", 24, '  ') { |opts|
@@ -67,8 +67,8 @@ options = OptionParser.new("", 24, '  ') { |opts|
     automatic = true
   }
   
-  opts.on("-u", "--shuffle [SEED]", Integer, "shuffle test file order using optional SEED") { |n|
-    shuffling = [:shuffle, n ? { random: Random.new(n) } : {}]
+  opts.on("-u", "--shuffle SEED", Integer, "use SEED for randomizing test file order") { |seed|
+    random = Random.new seed
   }
 
   opts.on('-n', '--name NAME', String,
@@ -117,7 +117,7 @@ require 'bacon'
 Bacon.extend Bacon.const_get(output) rescue abort "No such formatter: #{output}"
 Bacon.summary_on_exit
 
-files.send(*shuffling).each { |file|
+files.shuffle(random: random).each { |file|
   load file
 }
 


### PR DESCRIPTION
This is an idea that I'd like to put forth:
Add "shuffle" option. This adds a -u/--shuffle option (default is "do not shuffle", as it is currently).

Reason:
I really do like the new -a option. However, I do believe - ymmv - that tests should be run in random order to detect setup/code loading issues.

Currently, I do have to use something akin to `FileList["spec/#{dir}/*_spec.rb"].shuffle.join ' '` to make this happen, which negates the benefits of `-a`.

Always shuffling, adding a shuffle option (e.g. `-u`), or always shuffling on -a would be my wish-order.

I'd like to put this idea up for discussion. Thanks for considering it :)
